### PR TITLE
Fix arguments to completing-read

### DIFF
--- a/osm.el
+++ b/osm.el
@@ -957,7 +957,7 @@ MSG is a message prefix string."
          (selected (or (cdr (assoc
                              (completing-read
                               (format "Matches for '%s': " search)
-                              results nil t nil t)
+                              results nil t nil nil)
                              results))
                        (error "No selection"))))
     (osm-goto (car selected) (cadr selected)


### PR DESCRIPTION
The documentation for completing-read in my Emacs version (27.1) says that the sixth argument of `completing-read` should be "a symbol, which is the history list variable to use, or it can be a cons cell". When set to `t`, `helm-comp-read` raises an error.